### PR TITLE
Avoid ExpressionError

### DIFF
--- a/Products/SQLAlchemyDA/pt/info.zpt
+++ b/Products/SQLAlchemyDA/pt/info.zpt
@@ -34,7 +34,7 @@
 
                 <tr tal:repeat="k info_d">
                     <td class="form-label" tal:content="k"/>
-                    <td class="list-item" tal:content="info_d/?k" />
+                    <td class="list-item" tal:content="python: info_d[k]" />
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
ExpressionError: Not a valid path-expression.
- String:     "info_d/?k"
- Filename:   manage_workspace
- Expression: "info_d/?k"
- Filename:   manage_workspace
- Location:   (0:1338)
- Arguments:  repeat: {...} (0)
  
