### PR TITLE
Avoid Expression Error in the info.zpt template

### DIFF
--- a/Products/SQLAlchemyDA/CHANGES.txt
+++ b/Products/SQLAlchemyDA/CHANGES.txt
@@ -1,6 +1,7 @@
 0.5.2 (unreleased)
 ------------------
 - Fixed LP #639597
+- Avoid ExpressionError: Not a valid path-expression
 
 0.5.1 (2010-08-05)
 ------------------

--- a/Products/SQLAlchemyDA/pt/info.zpt
+++ b/Products/SQLAlchemyDA/pt/info.zpt
@@ -34,7 +34,7 @@
 
                 <tr tal:repeat="k info_d">
                     <td class="form-label" tal:content="k"/>
-                    <td class="list-item" tal:content="info_d/?k" />
+                    <td class="list-item" tal:content="python: info_d[k]" />
                 </tr>
             </tbody>
         </table>

--- a/Products/SQLAlchemyDA/pt/info.zpt
+++ b/Products/SQLAlchemyDA/pt/info.zpt
@@ -32,9 +32,13 @@
                     <td class="list-item" tal:content="context/connected" />
                 </tr>
 
+
                 <tr tal:repeat="k info_d">
                     <td class="form-label" tal:content="k"/>
-                    <td class="list-item" tal:content="python: info_d[k]" />
+                    <td class="list-item" tal:condition="python: not isinstance(info_d[k], dict)" tal:content="python: info_d[k]" />
+                    <td class="list-item" tal:condition="python: isinstance(info_d[k], dict)"
+                                          tal:content="structure python: ' '.join([ '<strong>%s:</strong> %s<br/>' %(key_dict[0], info_d[k][key_dict[0]]) for key_dict in [dct for dct in info_d[k].items()][0:] ]) "> </td>
+
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
**ExpressionError: Not a valid path-expression.**

```
 - String:     "info_d/?k"
 - Filename:   manage_workspace

 - Expression: "info_d/?k"
 - Filename:   manage_workspace
 - Location:   (0:1338)
 - Arguments:  repeat: {...} (0)

```
