### PR TITLE
Support SQLAlchemy 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.1 (unreleased)
 ----------------
 
+- Add support for SQLAlchemy 2.0
+  (`#16 <https://github.com/zopefoundation/Products.SQLAlchemyDA/issues/16>`_)
+
 
 2.0 (2023-02-01)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='Products.SQLAlchemyDA',
       python_requires='>=3.7',
       install_requires=[
         'setuptools',
-        'SQLAlchemy <2',  # z3c.sqlalchemy 1.5.2 incompatible with SQLAlchemy 2
+        'SQLAlchemy',
         'z3c.sqlalchemy >1.5.1',
         'Products.ZSQLMethods'],
       extras_require={'test': ['testfixtures']},

--- a/src/Products/SQLAlchemyDA/da.py
+++ b/src/Products/SQLAlchemyDA/da.py
@@ -17,9 +17,11 @@ from AccessControl.Permissions import view_management_screens
 from OFS.PropertyManager import PropertyManager
 from OFS.SimpleItem import SimpleItem
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from zope.component import getGlobalSiteManager
 
 from z3c.sqlalchemy import createSAWrapper
 from z3c.sqlalchemy import getSAWrapper
+from z3c.sqlalchemy.interfaces import ISQLAlchemyWrapper
 from zope.sqlalchemy import mark_changed
 
 
@@ -481,8 +483,8 @@ class SAWrapper(SimpleItem, PropertyManager):
         """ Intercept changed properties in order to perform
             further actions.
         """
-        from zope.component import unregisterUtility
-        unregisterUtility(name=self.util_id)
+        gsm = getGlobalSiteManager()
+        gsm.unregisterUtility(provided=ISQLAlchemyWrapper, name=self.util_id)
         self._new_utilid()
 
         return super().manage_editProperties(REQUEST)

--- a/src/Products/SQLAlchemyDA/da.py
+++ b/src/Products/SQLAlchemyDA/da.py
@@ -291,8 +291,6 @@ class SAWrapper(SimpleItem, PropertyManager):
     @property
     def engine_options(self):
         engine_options = dict(self.extra_engine_options)
-        engine_options.update(convert_unicode=self.convert_unicode,
-                              encoding=self.encoding)
         return engine_options
 
     def add_extra_engine_options(self, engine_options):


### PR DESCRIPTION
Fixes #16 

I don't know much about SQLAlchemy and don't use this code in any of my projects, so I can't say if it was OK to omit the engine options `convert_unicode` and `encoding`. Leaving them in produces tracebacks like this:

```python
Error in test testZsqlInsertWithCommit (Products.SQLAlchemyDA.tests.test_SQLAlchemyDA.SQLAlchemyDAFunctionalTests.testZsqlInsertWithCommit)
Traceback (most recent call last):
  File "/Users/jens/src/python/Python-3.11.3/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/Users/jens/src/python/Python-3.11.3/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/Users/jens/src/python/Python-3.11.3/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/tests/test_SQLAlchemyDA.py", line 169, in testZsqlInsertWithCommit
    self.createDA()
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/tests/test_SQLAlchemyDA.py", line 48, in createDA
    factory.manage_addSAWrapper(id=obj_id, title='da',
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/da.py", line 509, in manage_addSAWrapper
    self._setObject(id, wrapper.__of__(self))
  File "/Users/jens/src/.eggs/Zope-5.8.3-py3.11.egg/OFS/ObjectManager.py", line 370, in _setObject
    compatibilityCall('manage_afterAdd', ob, ob, self)
  File "/Users/jens/src/.eggs/Zope-5.8.3-py3.11.egg/OFS/subscribers.py", line 48, in compatibilityCall
    callManageAfterAdd(*args)
  File "/Users/jens/src/.eggs/Zope-5.8.3-py3.11.egg/OFS/subscribers.py", line 147, in callManageAfterAdd
    ob.manage_afterAdd(item, container)
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/da.py", line 167, in manage_afterAdd
    wrapper = self.sa_zope_wrapper()
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/da.py", line 213, in sa_zope_wrapper
    wrapper = self._supply_z3c_sa_wrapper()
  File "/Users/jens/src/zope/Products.SQLAlchemyDA/src/Products/SQLAlchemyDA/da.py", line 257, in _supply_z3c_sa_wrapper
    wrapper = createSAWrapper(
  File "/Users/jens/src/.eggs/z3c.sqlalchemy-2.1-py3.11.egg/z3c/sqlalchemy/util.py", line 71, in createSAWrapper
    wrapper = klass(dsn, model,
  File "/Users/jens/src/.eggs/z3c.sqlalchemy-2.1-py3.11.egg/z3c/sqlalchemy/base.py", line 63, in __init__
    self._createEngine()
  File "/Users/jens/src/.eggs/z3c.sqlalchemy-2.1-py3.11.egg/z3c/sqlalchemy/base.py", line 136, in _createEngine
    self._engine = create_engine(self.dsn, **self.engine_options)
  File "<string>", line 2, in create_engine
  File "/Users/jens/src/.eggs/SQLAlchemy-2.0.19-py3.11.egg/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/Users/jens/src/.eggs/SQLAlchemy-2.0.19-py3.11.egg/sqlalchemy/engine/create.py", line 680, in create_engine
    raise TypeError(
TypeError: Invalid argument(s) 'convert_unicode','encoding' sent to create_engine(), using configuration SQLiteDialect_pysqlite/QueuePool/Engine.  Please check that the keyword arguments are appropriate for this combination of components.

```